### PR TITLE
fix field delimiter of CF

### DIFF
--- a/cmd/s3s/main.go
+++ b/cmd/s3s/main.go
@@ -178,7 +178,7 @@ func cmd(ctx context.Context, paths []string) error {
 		queryInfo.RecordDelimiter = "\n"
 	case isCFLogs:
 		queryInfo.FormatType = s3s.FormatTypeCFLogs
-		queryInfo.FieldDelimiter = " "
+		queryInfo.FieldDelimiter = "\t"
 		queryInfo.RecordDelimiter = "\n"
 	default:
 		queryInfo.FormatType = s3s.FormatTypeJSON


### PR DESCRIPTION
Fix it

>Contain tab-separated values.
>https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#LogFileFormat