### PR TITLE
fix to stop when no prefix

### DIFF
--- a/prefix.go
+++ b/prefix.go
@@ -22,6 +22,10 @@ func (app *App) GetS3Dir(ctx context.Context, bucket string, prefix string) ([]s
 			return nil, err
 		}
 
+		if len(output.CommonPrefixes) == 0 {
+			break
+		}
+
 		pageKeys := make([]string, len(output.CommonPrefixes))
 		for i := range output.CommonPrefixes {
 			pageKeys[i] = *output.CommonPrefixes[i].Prefix


### PR DESCRIPTION
When no prefix in first directory like CloudFront Logs, `--delve` could no end to run.