### PR TITLE
Release for v0.4.0

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,35 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The pcpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versionFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release.
+#
+#   tagpr.tmplate (Optional)
+#       Pull request template in go template format
+#
+#   tagpr.release (Optional)
+#       GitHub Release creation behavior after tagging [true, draft, false]
+#       If this value is not set, the release is to be created.
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = -

--- a/.tagpr
+++ b/.tagpr
@@ -33,3 +33,4 @@
 	vPrefix = true
 	releaseBranch = main
 	versionFile = -
+	release = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+## [v0.4.0](https://github.com/koluku/s3s/compare/v0.3.3...v0.4.0) - 2022-09-27
+- add debug option by @koluku in https://github.com/koluku/s3s/pull/36
+- add dry run by @koluku in https://github.com/koluku/s3s/pull/39
+- install tagpr by @koluku in https://github.com/koluku/s3s/pull/42
+- (old) v0.4.0 Release PR by @koluku in https://github.com/koluku/s3s/pull/37
+- use github app instead of github pat by @koluku in https://github.com/koluku/s3s/pull/47
+- add column replacer by @koluku in https://github.com/koluku/s3s/pull/48
+- add new option --duration, --since and --until by @koluku in https://github.com/koluku/s3s/pull/49
+- fix missing time support in run by @koluku in https://github.com/koluku/s3s/pull/50
+- Update README by @koluku in https://github.com/koluku/s3s/pull/51
+
+## [v0.3.3](https://github.com/koluku/s3s/compare/v0.3.2...v0.3.3) - 2022-09-20
+- fix to stop when no prefix by @koluku in https://github.com/koluku/s3s/pull/38
+- fix reading json in loop by @koluku in https://github.com/koluku/s3s/pull/40
+- v0.3.3 Release by @koluku in https://github.com/koluku/s3s/pull/41
+
+## [v0.3.2](https://github.com/koluku/s3s/compare/v0.3.1...v0.3.2) - 2022-09-15
+- fix field delimiter of CF by @koluku in https://github.com/koluku/s3s/pull/35
+
+## [v0.3.1](https://github.com/koluku/s3s/compare/v0.3.0...v0.3.1) - 2022-09-15
+- Fix to read json by @koluku in https://github.com/koluku/s3s/pull/34
+
+## [v0.3.0](https://github.com/koluku/s3s/compare/v0.2.2...v0.3.0) - 2022-09-14
+- update for directory build by @koluku in https://github.com/koluku/s3s/pull/21
+- update s3api to get keys over 1000 by @koluku in https://github.com/koluku/s3s/pull/23
+- add limit option by @koluku in https://github.com/koluku/s3s/pull/24
+- add support count option by @koluku in https://github.com/koluku/s3s/pull/29
+- add support retry by @koluku in https://github.com/koluku/s3s/pull/30
+- CSV Support by @koluku in https://github.com/koluku/s3s/pull/32
+
+## [v0.2.2](https://github.com/koluku/s3s/compare/v0.2.1...v0.2.2) - 2022-09-02
+
+## [v0.2.1](https://github.com/koluku/s3s/compare/v0.2.0...v0.2.1) - 2022-09-02
+- Bump github.com/aws/aws-sdk-go-v2 from 1.14.0 to 1.16.11 by @dependabot in https://github.com/koluku/s3s/pull/11
+- Bump github.com/urfave/cli/v2 from 2.8.1 to 2.11.2 by @dependabot in https://github.com/koluku/s3s/pull/12
+- Bump github.com/aws/aws-sdk-go-v2/service/s3 from 1.25.0 to 1.27.5 by @dependabot in https://github.com/koluku/s3s/pull/13
+- Bump github.com/aws/aws-sdk-go-v2/config from 1.14.0 to 1.17.1 by @dependabot in https://github.com/koluku/s3s/pull/14
+- fix delve back to backet by @koluku in https://github.com/koluku/s3s/pull/20
+
+## [v0.2.0](https://github.com/koluku/s3s/compare/v0.1.0...v0.2.0) - 2022-08-25
+- Add fuzzy search as delve option by @koluku in https://github.com/koluku/s3s/pull/15
+- Release v0.2.0 by @koluku in https://github.com/koluku/s3s/pull/16
+
+## [v0.1.0](https://github.com/koluku/s3s/compare/v0.0.0...v0.1.0) - 2022-08-22
+- Suggest input compression type from suffix of key by @koluku in https://github.com/koluku/s3s/pull/4
+- Add Example README by @koluku in https://github.com/koluku/s3s/pull/5
+- fix option  of region by @koluku in https://github.com/koluku/s3s/pull/6
+- enable prerelase by @koluku in https://github.com/koluku/s3s/pull/7
+- Accept all tag in release action by @koluku in https://github.com/koluku/s3s/pull/8
+- Reduce latency by processing API requests in parallel by @koluku in https://github.com/koluku/s3s/pull/9
+- Update README for v0.1.0 and Add MIT LICENSE by @koluku in https://github.com/koluku/s3s/pull/10
+
+## [v0.0.0](https://github.com/koluku/s3s/commits/v0.0.0) - 2022-06-10
+- Add Unit Test by @koluku in https://github.com/koluku/s3s/pull/1
+- change cli library by @koluku in https://github.com/koluku/s3s/pull/2
+- Automatically release by @koluku in https://github.com/koluku/s3s/pull/3


### PR DESCRIPTION
This pull request is for the next release as v0.4.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.4.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* add debug option by @koluku in https://github.com/koluku/s3s/pull/36
* add dry run by @koluku in https://github.com/koluku/s3s/pull/39
* install tagpr by @koluku in https://github.com/koluku/s3s/pull/42
* (old) v0.4.0 Release PR by @koluku in https://github.com/koluku/s3s/pull/37
* use github app instead of github pat by @koluku in https://github.com/koluku/s3s/pull/47
* add column replacer by @koluku in https://github.com/koluku/s3s/pull/48
* add new option --duration, --since and --until by @koluku in https://github.com/koluku/s3s/pull/49
* fix missing time support in run by @koluku in https://github.com/koluku/s3s/pull/50
* Update README by @koluku in https://github.com/koluku/s3s/pull/51


**Full Changelog**: https://github.com/koluku/s3s/compare/v0.3.3...v0.4.0