### PR TITLE
add new option --duration, --since and --until

### DIFF
--- a/cmd/s3s/main.go
+++ b/cmd/s3s/main.go
@@ -260,7 +260,6 @@ func cmd(ctx context.Context, paths []string) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		fmt.Printf("%+v\n", keyInfo)
 		fmt.Printf("all scan byte: %s\n", humanize.Bytes(uint64(scanByte)))
 		fmt.Printf("file count: %s\n", humanize.Comma(int64(count)))
 	} else {

--- a/cmd/s3s/main.go
+++ b/cmd/s3s/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/koluku/s3s"
@@ -37,6 +38,12 @@ var (
 	isCSV     bool
 	isALBLogs bool
 	isCFLogs  bool
+
+	duration time.Duration
+	since    time.Time
+	cliSince cli.Timestamp
+	until    time.Time
+	cliUntil cli.Timestamp
 
 	// command option
 	threadCount int
@@ -103,6 +110,25 @@ func main() {
 				Usage:       "",
 				Destination: &isCFLogs,
 			},
+			&cli.DurationFlag{
+				Name:        "duration",
+				Usage:       `from current time if alb or cf (ex: "2h3m")`,
+				Destination: &duration,
+			},
+			&cli.TimestampFlag{
+				Name:        "since",
+				Usage:       `end at if alb or cf (ex: "2006-01-02 15:04:05")`,
+				Layout:      "2006-01-02 15:04:05",
+				Timezone:    time.UTC,
+				Destination: &cliSince,
+			},
+			&cli.TimestampFlag{
+				Name:        "until",
+				Usage:       `start at if alb or cf (ex: "2006-01-02 15:04:05")`,
+				Layout:      "2006-01-02 15:04:05",
+				Timezone:    time.UTC,
+				Destination: &cliUntil,
+			},
 			&cli.IntFlag{
 				Name:        "thread-count",
 				Aliases:     []string{"t, thread_count"},
@@ -138,6 +164,13 @@ func main() {
 			},
 		},
 		Action: func(c *cli.Context) error {
+			if cliSince.Value() != nil {
+				since = *cliSince.Value()
+			}
+			if cliUntil.Value() != nil {
+				until = *cliUntil.Value()
+			}
+
 			if err := cmd(c.Context, c.Args().Slice()); err != nil {
 				return errors.WithStack(err)
 			}
@@ -188,6 +221,9 @@ func cmd(ctx context.Context, paths []string) error {
 	queryInfo := &s3s.QueryInfo{
 		IsCountMode: isCount,
 	}
+	keyInfo := &s3s.KeyInfo{
+		KeyType: s3s.KeyTypeNone,
+	}
 	switch {
 	case isCSV:
 		queryInfo.FormatType = s3s.FormatTypeCSV
@@ -197,23 +233,40 @@ func cmd(ctx context.Context, paths []string) error {
 		queryInfo.FormatType = s3s.FormatTypeALBLogs
 		queryInfo.FieldDelimiter = " "
 		queryInfo.RecordDelimiter = "\n"
+		keyInfo.KeyType = s3s.KeyTypeALB
+		if duration != 0 {
+			keyInfo.Since = time.Now().UTC().Add(duration * -1)
+		} else {
+			keyInfo.Since = since
+			keyInfo.Until = until
+		}
 	case isCFLogs:
 		queryInfo.FormatType = s3s.FormatTypeCFLogs
 		queryInfo.FieldDelimiter = "\t"
 		queryInfo.RecordDelimiter = "\n"
+		keyInfo.KeyType = s3s.KeyTypeCF
+		if duration != 0 {
+			keyInfo.Since = time.Now().UTC().Add(duration * -1)
+		} else {
+			keyInfo.Since = since
+			keyInfo.Until = until
+		}
 	default:
 		queryInfo.FormatType = s3s.FormatTypeJSON
 	}
 
 	if isDryRun {
-		scanByte, count, err := app.DryRun(ctx, paths, queryStr, queryInfo)
+		scanByte, count, err := app.DryRun(ctx, paths, keyInfo, queryStr, queryInfo)
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		fmt.Printf("%+v\n", keyInfo)
 		fmt.Printf("all scan byte: %s\n", humanize.Bytes(uint64(scanByte)))
 		fmt.Printf("file count: %s\n", humanize.Comma(int64(count)))
 	} else {
-		app.Run(ctx, paths, queryStr, queryInfo)
+		if err := app.Run(ctx, paths, keyInfo, queryStr, queryInfo); err != nil {
+			return errors.WithStack(err)
+		}
 	}
 
 	// Finalize

--- a/prefix.go
+++ b/prefix.go
@@ -10,6 +10,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	ErrTimeParseFailed = "time parce failed"
+)
+
 func (app *App) GetS3Dir(ctx context.Context, bucket string, prefix string) ([]string, error) {
 	input := &s3.ListObjectsV2Input{
 		Bucket:    aws.String(bucket),
@@ -144,7 +148,7 @@ func isTimeWithinWhenALB(key string, since time.Time, until time.Time) (bool, er
 
 	t, err := time.Parse("_20060102T1504Z_", timeStr)
 	if err != nil {
-		return false, errors.WithStack(err)
+		return false, errors.Wrap(err, ErrTimeParseFailed)
 	}
 
 	if !since.IsZero() && t.Before(since) {

--- a/prefix.go
+++ b/prefix.go
@@ -61,6 +61,24 @@ type ObjectInfo struct {
 	Size   int64
 }
 
+func (app *App) GetS3OneKey(ctx context.Context, bucket string, prefix string) (*ObjectInfo, error) {
+	input := &s3.ListObjectsV2Input{
+		Bucket:  aws.String(bucket),
+		Prefix:  aws.String(prefix),
+		MaxKeys: 1,
+	}
+	output, err := app.s3.ListObjectsV2(ctx, input)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &ObjectInfo{
+		Bucket: bucket,
+		Key:    *output.Contents[0].Key,
+		Size:   output.Contents[0].Size,
+	}, nil
+}
+
 func (app *App) GetS3Keys(ctx context.Context, sender chan<- ObjectInfo, bucket string, prefix string, info *KeyInfo) error {
 	input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucket),
@@ -68,21 +86,14 @@ func (app *App) GetS3Keys(ctx context.Context, sender chan<- ObjectInfo, bucket 
 	}
 	pagenator := s3.NewListObjectsV2Paginator(app.s3, input)
 
-	for pagenator.HasMorePages() {
-		output, err := pagenator.NextPage(ctx)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		for i := range output.Contents {
-			switch info.KeyType {
-			case KeyTypeNone:
-				sender <- ObjectInfo{
-					Bucket: bucket,
-					Key:    *output.Contents[i].Key,
-					Size:   output.Contents[i].Size,
-				}
-			case KeyTypeALB:
+	switch info.KeyType {
+	case KeyTypeALB:
+		for pagenator.HasMorePages() {
+			output, err := pagenator.NextPage(ctx)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			for i := range output.Contents {
 				if isTimeZeroRange(info.Since, info.Until) {
 					sender <- ObjectInfo{
 						Bucket: bucket,
@@ -91,7 +102,7 @@ func (app *App) GetS3Keys(ctx context.Context, sender chan<- ObjectInfo, bucket 
 					}
 					continue
 				}
-				if isTimeWithin(*output.Contents[i].Key, info.Since, info.Until) {
+				if isTimeWithinWhenALB(*output.Contents[i].Key, info.Since, info.Until) {
 					sender <- ObjectInfo{
 						Bucket: bucket,
 						Key:    *output.Contents[i].Key,
@@ -99,7 +110,20 @@ func (app *App) GetS3Keys(ctx context.Context, sender chan<- ObjectInfo, bucket 
 					}
 					continue
 				}
-			case KeyTypeCF:
+			}
+		}
+	default:
+		for pagenator.HasMorePages() {
+			output, err := pagenator.NextPage(ctx)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			for i := range output.Contents {
+				sender <- ObjectInfo{
+					Bucket: bucket,
+					Key:    *output.Contents[i].Key,
+					Size:   output.Contents[i].Size,
+				}
 			}
 		}
 	}
@@ -111,7 +135,7 @@ func isTimeZeroRange(since time.Time, until time.Time) bool {
 	return since.IsZero() && until.IsZero()
 }
 
-func isTimeWithin(key string, since time.Time, until time.Time) bool {
+func isTimeWithinWhenALB(key string, since time.Time, until time.Time) bool {
 	rep := regexp.MustCompile(`_\d{8}T\d{4}Z_`)
 	timeStr := rep.FindString(key)
 

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -1,6 +1,7 @@
 package s3s
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -51,60 +52,76 @@ func TestIsTimeZeroRange(t *testing.T) {
 
 func TestIsTimeWithinWhenALB(t *testing.T) {
 	cases := []struct {
-		name  string
-		key   string
-		since time.Time
-		until time.Time
-		want  bool
+		name    string
+		key     string
+		since   time.Time
+		until   time.Time
+		want    bool
+		wantErr string
 	}{
 		{
-			name:  "include",
-			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
-			since: time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
-			until: time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
-			want:  true,
+			name:    "include",
+			key:     "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since:   time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
+			until:   time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			want:    true,
+			wantErr: "",
 		},
 		{
-			name:  "include: in border",
-			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
-			since: time.Date(2022, 9, 27, 0, 0, 0, 0, time.UTC),
-			until: time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
-			want:  true,
+			name:    "include: in border",
+			key:     "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since:   time.Date(2022, 9, 27, 0, 0, 0, 0, time.UTC),
+			until:   time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			want:    true,
+			wantErr: "",
 		},
 		{
-			name:  "exclude",
-			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
-			since: time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
-			until: time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
-			want:  false,
+			name:    "exclude",
+			key:     "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since:   time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			until:   time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			want:    false,
+			wantErr: "",
 		},
 		{
-			name:  "exclude: when since only",
-			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
-			since: time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
-			until: time.Time{},
-			want:  false,
+			name:    "exclude: when since only",
+			key:     "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since:   time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			until:   time.Time{},
+			want:    false,
+			wantErr: "",
 		},
 		{
-			name:  "include: when since only",
-			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
-			since: time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
-			until: time.Time{},
-			want:  true,
+			name:    "include: when since only",
+			key:     "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since:   time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
+			until:   time.Time{},
+			want:    true,
+			wantErr: "",
 		},
 		{
-			name:  "exclude: when until only",
-			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
-			since: time.Time{},
-			until: time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
-			want:  false,
+			name:    "exclude: when until only",
+			key:     "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since:   time.Time{},
+			until:   time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
+			want:    false,
+			wantErr: "",
 		},
 		{
-			name:  "include: when until only",
-			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
-			since: time.Time{},
-			until: time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
-			want:  true,
+			name:    "include: when until only",
+			key:     "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since:   time.Time{},
+			until:   time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			want:    true,
+			wantErr: "",
+		},
+		{
+			name:    "error",
+			key:     "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_2022.09.27T00.00Z_192.168.1.1_123abc.log.gz",
+			since:   time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
+			until:   time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			want:    false,
+			wantErr: ErrTimeParseFailed,
 		},
 	}
 
@@ -112,7 +129,10 @@ func TestIsTimeWithinWhenALB(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := isTimeWithinWhenALB(tt.key, tt.since, tt.until)
+			got, err := isTimeWithinWhenALB(tt.key, tt.since, tt.until)
+			if err != nil && !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("err mismatch want = %+v, but got = %+v", tt.wantErr, err)
+			}
 			if got != tt.want {
 				t.Errorf("want = %+v, but got = %+v", tt.want, got)
 			}

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -1,0 +1,123 @@
+package s3s
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsTimeZeroRange(t *testing.T) {
+
+	cases := []struct {
+		name  string
+		since time.Time
+		until time.Time
+		want  bool
+	}{
+		{
+			name:  "since and until are not zero time",
+			since: time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
+			until: time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			want:  false,
+		},
+		{
+			name:  "since is zero time",
+			since: time.Time{},
+			until: time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			want:  false,
+		},
+		{
+			name:  "until is zero time",
+			since: time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
+			until: time.Time{},
+			want:  false,
+		},
+		{
+			name:  "since and until are zero time",
+			since: time.Time{},
+			until: time.Time{},
+			want:  true,
+		},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isTimeZeroRange(tt.since, tt.until)
+			if got != tt.want {
+				t.Errorf("want = %+v, but got = %+v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestIsTimeWithin(t *testing.T) {
+
+	cases := []struct {
+		name  string
+		key   string
+		since time.Time
+		until time.Time
+		want  bool
+	}{
+		{
+			name:  "include",
+			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since: time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
+			until: time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			want:  true,
+		},
+		{
+			name:  "include: in border",
+			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since: time.Date(2022, 9, 27, 0, 0, 0, 0, time.UTC),
+			until: time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			want:  true,
+		},
+		{
+			name:  "exclude",
+			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since: time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			until: time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			want:  false,
+		},
+		{
+			name:  "exclude: when since only",
+			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since: time.Date(2022, 9, 28, 0, 0, 0, 0, time.UTC),
+			until: time.Time{},
+			want:  false,
+		},
+		{
+			name:  "include: when since only",
+			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since: time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
+			until: time.Time{},
+			want:  true,
+		},
+		{
+			name:  "exclude: when until only",
+			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since: time.Time{},
+			until: time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC),
+			want:  false,
+		},
+		{
+			name:  "include: when until only",
+			key:   "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T0000Z_192.168.1.1_123abc.log.gz",
+			since: time.Time{},
+			until: time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			want:  true,
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isTimeWithin(tt.key, tt.since, tt.until)
+			if got != tt.want {
+				t.Errorf("want = %+v, but got = %+v", tt.want, got)
+			}
+		})
+	}
+}

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestIsTimeZeroRange(t *testing.T) {
-
 	cases := []struct {
 		name  string
 		since time.Time
@@ -50,8 +49,7 @@ func TestIsTimeZeroRange(t *testing.T) {
 	}
 }
 
-func TestIsTimeWithin(t *testing.T) {
-
+func TestIsTimeWithinWhenALB(t *testing.T) {
 	cases := []struct {
 		name  string
 		key   string
@@ -114,7 +112,7 @@ func TestIsTimeWithin(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := isTimeWithin(tt.key, tt.since, tt.until)
+			got := isTimeWithinWhenALB(tt.key, tt.since, tt.until)
 			if got != tt.want {
 				t.Errorf("want = %+v, but got = %+v", tt.want, got)
 			}


### PR DESCRIPTION
support log range when alb and cf

`--duration` is a duration from now.
`--since` is start time
`--until` is end time

however, s3s stop when you target cloudfront and using `--duration` or `--since` only, because s3s hit too many keys.