### PR TITLE
remove region option

### DIFF
--- a/cmd/s3s/main.go
+++ b/cmd/s3s/main.go
@@ -26,9 +26,6 @@ var (
 	// goreleaser
 	Version = "current"
 
-	// AWS
-	region string
-
 	// S3 Select Query
 	queryStr string
 	where    string
@@ -62,13 +59,6 @@ func main() {
 		Version: Version,
 		Usage:   "Easy S3 select like searching in directories",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:        "region",
-				Usage:       "region of target s3 bucket exist",
-				Value:       os.Getenv("AWS_REGION"),
-				DefaultText: "ENV[\"AWS_REGION\"]",
-				Destination: &region,
-			},
 			&cli.StringFlag{
 				Name:        "query",
 				Aliases:     []string{"q"},
@@ -201,7 +191,7 @@ func cmd(ctx context.Context, paths []string) error {
 	}
 
 	// Initialize
-	app, err := s3s.NewApp(ctx, region, maxRetries, threadCount)
+	app, err := s3s.NewApp(ctx, maxRetries, threadCount)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/s3s.go
+++ b/s3s.go
@@ -20,8 +20,8 @@ type App struct {
 	s3          *s3.Client
 }
 
-func NewApp(ctx context.Context, region string, maxRetries int, threadCount int) (*App, error) {
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+func NewApp(ctx context.Context, maxRetries int, threadCount int) (*App, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
In most situations `$ AWS_PROFILE=profile s3s` would be sufficient.
If you need region option, you should use `AWS_REGION`.