### PR TITLE
Fix time options for ALB logs

### DIFF
--- a/cmd/s3s/checker.go
+++ b/cmd/s3s/checker.go
@@ -27,6 +27,12 @@ func checkTime(duration time.Duration, until, since time.Time) error {
 	if duration > 0 && (!until.IsZero() || !since.IsZero()) {
 		return errors.Errorf("duration with since/until error")
 	}
+	if !since.IsZero() && until.IsZero() {
+		return errors.Errorf("since only will too many logs hit")
+	}
+	if since.IsZero() && !until.IsZero() {
+		return errors.Errorf("until only will too many logs hit")
+	}
 	if !until.IsZero() && !since.IsZero() && !since.Before(until) {
 		return errors.Errorf("since >= until error")
 	}

--- a/cmd/s3s/main.go
+++ b/cmd/s3s/main.go
@@ -208,8 +208,10 @@ func cmd(ctx context.Context, paths []string) error {
 	if err := checkArgs(paths); err != nil {
 		return errors.WithStack(err)
 	}
-	if err := checkTime(duration, until, since); err != nil {
-		return errors.WithStack(err)
+	if isALBLogs || isCFLogs {
+		if err := checkTime(duration, until, since); err != nil {
+			return errors.WithStack(err)
+		}
 	}
 	if err := checkQuery(queryStr, where, limit, isCount); err != nil {
 		return errors.WithStack(err)

--- a/prefix.go
+++ b/prefix.go
@@ -2,6 +2,10 @@ package s3s
 
 import (
 	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -91,38 +95,107 @@ func (app *App) GetS3Keys(ctx context.Context, sender chan<- ObjectInfo, bucket 
 		}
 
 		for i := range output.Contents {
-			switch info.KeyType {
-			case KeyTypeALB:
-				if isTimeZeroRange(info.Since, info.Until) {
-					sender <- ObjectInfo{
-						Bucket: bucket,
-						Key:    *output.Contents[i].Key,
-						Size:   output.Contents[i].Size,
-					}
-					continue
-				}
-
-				endTime, err := getALBKeyEndTime(*output.Contents[i].Key)
-				if err != nil {
-					return errors.WithStack(err)
-				}
-				if isTimeWithin(endTime, info.Since, info.Until) {
-					sender <- ObjectInfo{
-						Bucket: bucket,
-						Key:    *output.Contents[i].Key,
-						Size:   output.Contents[i].Size,
-					}
-					continue
-				}
-			default:
-				sender <- ObjectInfo{
-					Bucket: bucket,
-					Key:    *output.Contents[i].Key,
-					Size:   output.Contents[i].Size,
-				}
+			sender <- ObjectInfo{
+				Bucket: bucket,
+				Key:    *output.Contents[i].Key,
+				Size:   output.Contents[i].Size,
 			}
 		}
 	}
 
 	return nil
+}
+
+func (app *App) OptimizateALBPaths(ctx context.Context, paths []string, keyInfo *KeyInfo) ([]string, error) {
+	if keyInfo.KeyType != KeyTypeALB || isTimeZeroRange(keyInfo.Since, keyInfo.Until) {
+		return nil, nil
+	}
+
+	var npaths []string
+	for _, path := range paths {
+		u, err := url.Parse(path)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		var bucket, prefix string
+		bucket = u.Hostname()
+		prefix = strings.TrimPrefix(u.Path, "/")
+		oi, err := app.GetS3OneKey(ctx, bucket, prefix)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		rep := regexp.MustCompile(`(^.*)\d{4}/\d{2}/\d{2}(.*)_\d{8}T\d{4}Z_`)
+		submatches := rep.FindStringSubmatch(oi.Key)
+		if len(submatches) == 0 {
+			return nil, fmt.Errorf("non-match alb path")
+		}
+		prefixA := submatches[1]
+		prefixB := submatches[2]
+
+		since := roundUpTime(keyInfo.Since, time.Minute*5)
+		until := roundUpTime(keyInfo.Until, time.Minute*5)
+
+		for {
+			if since.After(until) {
+				break
+			}
+			delta := until.Sub(since)
+			if delta >= time.Hour*24 {
+				npaths = append(npaths, fmt.Sprintf("s3://%s/%s%s%s_%s", bucket, prefixA, since.Format("2006/01/02"), prefixB, since.Format("20060102")))
+				since = since.Add(time.Hour * 24)
+			} else if delta >= time.Hour {
+				npaths = append(npaths, fmt.Sprintf("s3://%s/%s%s%s_%s", bucket, prefixA, since.Format("2006/01/02"), prefixB, since.Format("20060102T15")))
+				since = since.Add(time.Hour)
+			} else {
+				npaths = append(npaths, fmt.Sprintf("s3://%s/%s%s%s_%s", bucket, prefixA, since.Format("2006/01/02"), prefixB, since.Format("20060102T1504Z")))
+				since = since.Add(time.Minute * 5)
+			}
+		}
+	}
+
+	return npaths, nil
+}
+
+func (app *App) OptimizateCFPaths(ctx context.Context, paths []string, keyInfo *KeyInfo) ([]string, error) {
+	if keyInfo.KeyType != KeyTypeCF || isTimeZeroRange(keyInfo.Since, keyInfo.Until) {
+		return nil, nil
+	}
+
+	var npaths []string
+	for _, path := range paths {
+		u, err := url.Parse(path)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		var bucket, prefix string
+		bucket = u.Hostname()
+		prefix = strings.TrimPrefix(u.Path, "/")
+		oi, err := app.GetS3OneKey(ctx, bucket, prefix)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		rep := regexp.MustCompile(`/?.+?\.`)
+		distribution := rep.FindString(oi.Key)
+		distribution = strings.TrimPrefix(distribution, "/")
+
+		since := keyInfo.Since
+		until := keyInfo.Until
+		for {
+			if since.After(until) {
+				break
+			}
+			delta := until.Sub(since)
+			if delta >= time.Hour*24 {
+				npaths = append(npaths, fmt.Sprintf("s3://%s/%s%s", bucket, distribution, since.Format("2006-01-02")))
+				since = since.Add(time.Hour * 24)
+			} else {
+				npaths = append(npaths, fmt.Sprintf("s3://%s/%s%s", bucket, distribution, since.Format("2006-01-02-15.")))
+				since = since.Add(time.Hour)
+			}
+		}
+	}
+
+	return npaths, nil
 }

--- a/time.go
+++ b/time.go
@@ -1,10 +1,7 @@
 package s3s
 
 import (
-	"regexp"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -18,31 +15,15 @@ func roundUpTime(t time.Time, d time.Duration) time.Time {
 	return t
 }
 
-func roundDownTime(t time.Time, d time.Duration) time.Time {
-	return t.Truncate(d)
-}
-
 func isTimeZeroRange(since time.Time, until time.Time) bool {
 	return since.IsZero() && until.IsZero()
 }
 
-func getALBKeyEndTime(key string) (time.Time, error) {
-	rep := regexp.MustCompile(`_\d{8}T\d{4}Z_`)
-	timeStr := rep.FindString(key)
-
-	t, err := time.Parse("_20060102T1504Z_", timeStr)
-	if err != nil {
-		return time.Time{}, errors.Wrap(err, ErrTimeParseFailed)
-	}
-
-	return t, nil
-}
-
 func isTimeWithin(t time.Time, since time.Time, until time.Time) bool {
-	if !since.IsZero() && t.Before(roundDownTime(since, time.Minute*5)) {
+	if !since.IsZero() && t.Before(since) {
 		return false
 	}
-	if !until.IsZero() && t.After(roundUpTime(until, time.Minute*5)) {
+	if !until.IsZero() && t.After(until) {
 		return false
 	}
 	return true

--- a/time_test.go
+++ b/time_test.go
@@ -1,7 +1,6 @@
 package s3s
 
 import (
-	"strings"
 	"testing"
 	"time"
 )
@@ -49,65 +48,6 @@ func TestRoundUpTime(t *testing.T) {
 	}
 }
 
-func BenchmarkRoundUpTime(b *testing.B) {
-	t := time.Date(2022, 9, 27, 12, 35, 0, 0, time.UTC)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		roundUpTime(t, time.Minute*5)
-	}
-}
-
-func TestRoundDownTime(t *testing.T) {
-	cases := []struct {
-		input time.Time
-		want  time.Time
-	}{
-		{
-			input: time.Date(2022, 9, 28, 12, 34, 0, 0, time.UTC),
-			want:  time.Date(2022, 9, 28, 12, 30, 0, 0, time.UTC),
-		},
-		{
-			input: time.Date(2022, 9, 28, 12, 35, 0, 0, time.UTC),
-			want:  time.Date(2022, 9, 28, 12, 35, 0, 0, time.UTC),
-		},
-		{
-			input: time.Date(2022, 9, 28, 12, 36, 0, 0, time.UTC),
-			want:  time.Date(2022, 9, 28, 12, 35, 0, 0, time.UTC),
-		},
-		{
-			input: time.Date(2022, 9, 28, 12, 39, 0, 0, time.UTC),
-			want:  time.Date(2022, 9, 28, 12, 35, 0, 0, time.UTC),
-		},
-		{
-			input: time.Date(2022, 9, 28, 12, 40, 0, 0, time.UTC),
-			want:  time.Date(2022, 9, 28, 12, 40, 0, 0, time.UTC),
-		},
-		{
-			input: time.Date(2022, 9, 28, 12, 41, 0, 0, time.UTC),
-			want:  time.Date(2022, 9, 28, 12, 40, 0, 0, time.UTC),
-		},
-	}
-
-	for _, tt := range cases {
-		tt := tt
-		t.Run(tt.input.String(), func(t *testing.T) {
-			t.Parallel()
-			got := roundDownTime(tt.input, time.Minute*5)
-			if got != tt.want {
-				t.Errorf("want = %+v, but got = %+v", tt.want, got)
-			}
-		})
-	}
-}
-
-func BenchmarkRoundDownTime(b *testing.B) {
-	t := time.Date(2022, 9, 27, 12, 35, 0, 0, time.UTC)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		roundDownTime(t, time.Minute*5)
-	}
-}
-
 func TestIsTimeZeroRange(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -145,42 +85,6 @@ func TestIsTimeZeroRange(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := isTimeZeroRange(tt.since, tt.until)
-			if got != tt.want {
-				t.Errorf("want = %+v, but got = %+v", tt.want, got)
-			}
-		})
-	}
-}
-
-func TestGetALBKeyEndTime(t *testing.T) {
-	cases := []struct {
-		name    string
-		key     string
-		want    time.Time
-		wantErr string
-	}{
-		{
-			name:    "success",
-			key:     "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_20220927T1234Z_192.168.1.1_123abc.log.gz",
-			want:    time.Date(2022, 9, 27, 12, 34, 0, 0, time.UTC),
-			wantErr: "",
-		},
-		{
-			name:    "error",
-			key:     "alb-logs/AWSLogs/aws-account-id/elasticloadbalancing/region/2022/09/27/aws-account-id_elasticloadbalancing_region_app.load-balancer-id_2022.09.27T00.00Z_192.168.1.1_123abc.log.gz",
-			want:    time.Time{},
-			wantErr: ErrTimeParseFailed,
-		},
-	}
-
-	for _, tt := range cases {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got, err := getALBKeyEndTime(tt.key)
-			if err != nil && !strings.Contains(err.Error(), tt.wantErr) {
-				t.Errorf("err mismatch want = %+v, but got = %+v", tt.wantErr, err)
-			}
 			if got != tt.want {
 				t.Errorf("want = %+v, but got = %+v", tt.want, got)
 			}
@@ -264,11 +168,11 @@ func TestIsTimeWithin(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("want = %+v, but got = %+v", tt.want, got)
 				if tt.since.IsZero() {
-					t.Errorf("%v <= until: %v", tt.input, roundUpTime(tt.until, time.Minute*5))
+					t.Errorf("%v <= until: %v", tt.input, tt.until)
 				} else if tt.until.IsZero() {
-					t.Errorf("since: %v <= %v", roundDownTime(tt.since, time.Minute*5), tt.input)
+					t.Errorf("since: %v <= %v", tt.since, tt.input)
 				} else {
-					t.Errorf("since: %v <= %v <= until: %v", roundDownTime(tt.since, time.Minute*5), tt.input, roundUpTime(tt.until, time.Minute*5))
+					t.Errorf("since: %v <= %v <= until: %v", tt.since, tt.input, tt.until)
 				}
 			}
 		})


### PR DESCRIPTION
It was not worked when searching from alb logs using time options. Fixed it.
And, searching from ALB logs and CF logs needs time options because it will be too many hits.