### PR TITLE
fix that delve option doesn't work

### DIFF
--- a/cmd/s3s/main.go
+++ b/cmd/s3s/main.go
@@ -139,6 +139,11 @@ func main() {
 				Destination: &isDryRun,
 			},
 			&cli.BoolFlag{
+				Name:    "interactive",
+				Aliases: []string{"i"},
+				Usage:   "use as interactive mode",
+			},
+			&cli.BoolFlag{
 				Name:        "debug",
 				Usage:       "erorr check for developer",
 				Destination: &isDebug,
@@ -152,7 +157,7 @@ func main() {
 				until = *cliUntil.Value()
 			}
 
-			if c.NArg() == 0 {
+			if c.Bool("interactive") {
 				if err := prompter(c.Context); err != nil {
 					return errors.WithStack(err)
 				}


### PR DESCRIPTION
The interactive mode was introduced at v0.5.0, but using no args affects `--delve` option like below.

```console
$ s3s --version
s3s version v0.5.0

$ s3s --delve
Please use `exit` or `Ctrl-D` to exit this program.
>>>
```

So, add `--interactive` or `-i` avoid the interactive mode and delve option conflict.
And no args occur an error (same as v0.4.3)