### PR TITLE
Fix format type selection bug, always json

### DIFF
--- a/s3s.go
+++ b/s3s.go
@@ -189,6 +189,7 @@ LOOP:
 					Query:  query.Query,
 				}
 			}
+			input.FormatType = query.FormatType
 
 			eg.Go(func() error {
 				if err := c.s3Select(egctx, in, input, option); err != nil {

--- a/s3s.go
+++ b/s3s.go
@@ -21,7 +21,7 @@ const (
 type FormatType int
 
 const (
-	FormatTypeJSON FormatType = iota
+	FormatTypeJSON FormatType = iota + 1
 	FormatTypeCSV
 	FormatTypeALBLogs
 	FormatTypeCFLogs


### PR DESCRIPTION
The format will always be JSON no matter what option you choose.
This is because I forgot to transfer the Formt specification when repacking the structure.

